### PR TITLE
fix: validate mode arg, prevent profiling in read-only, fix BSON exports

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -21,6 +21,14 @@ export function parseArgs(): AppConfig {
     }
   }
 
+  const normalizedMode = mode.toLowerCase().trim();
+  if (normalizedMode !== 'read-only' && normalizedMode !== 'read-write') {
+    console.error(`Invalid mode "${mode}". Must be "read-only" or "read-write". Defaulting to read-only for safety.`);
+    mode = 'read-only';
+  } else {
+    mode = normalizedMode;
+  }
+
   uri = uri || 'mongodb://localhost:27017';
   dbName = dbName || 'test';
 


### PR DESCRIPTION
- Validate --mode CLI argument and default to read-only on invalid input
- Prevent getSlowestOperations from enabling profiling in read-only mode
- Convert BSON types to Extended JSON for all export formats (JSON, JSONL, CSV)