### PR TITLE
fix: clear rate limiter interval on shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { MongoClient } from 'mongodb';
 import { parseArgs } from './config/environment.js';
 import { setupServer } from './server/setup.js';
+import { stopRateLimiterCleanup } from './utils/rate-limiter.js';
 
 const { uri, dbName, mode } = parseArgs();
 const client = new MongoClient(uri);
@@ -14,6 +15,7 @@ async function shutdown() {
   isShuttingDown = true;
 
   try {
+    stopRateLimiterCleanup();
     await client.close();
   } catch (error) {
     console.error('Error during shutdown:', error);

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -12,7 +12,11 @@ function cleanupExpiredEntries(): void {
   }
 }
 
-setInterval(cleanupExpiredEntries, CLEANUP_INTERVAL_MS);
+const cleanupIntervalId = setInterval(cleanupExpiredEntries, CLEANUP_INTERVAL_MS);
+
+export function stopRateLimiterCleanup(): void {
+  clearInterval(cleanupIntervalId);
+}
 
 export function checkAdminRateLimit(operation: string): boolean {
   const now = Date.now();


### PR DESCRIPTION
## Summary
- Store the interval ID from `setInterval` in `src/utils/rate-limiter.ts`
- Export a `stopRateLimiterCleanup()` function that calls `clearInterval`
- Call `stopRateLimiterCleanup()` in the `shutdown()` handler in `src/index.ts` before `client.close()`

This prevents the cleanup interval from running indefinitely after the process begins shutting down, fixing the memory leak.

## Changes
- **`src/utils/rate-limiter.ts`** — Store interval ID, export cleanup function
- **`src/index.ts`** — Import and call cleanup in shutdown handler

Fixes #16