### PR TITLE
fix: add connection health checks and graceful error recovery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ async function shutdown() {
 async function main() {
   try {
     await client.connect();
+    await client.db(dbName).command({ ping: 1 });
     await setupServer(client, dbName, mode);
   } catch (error) {
     console.error('Error:', error instanceof Error ? error.message : String(error));

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -10,6 +10,25 @@ import { registerIndexManagementTools } from './index-management.js';
 import { registerAdvancedOperations } from './advanced-operations.js';
 import { registerDataQualityTools } from './data-quality.js';
 import { registerTemporalTools } from './temporal.js';
+import { withConnectionGuard } from '../utils/connection-guard.js';
+
+function wrapServerWithConnectionGuard(server: McpServer): McpServer {
+  const originalTool = server.tool.bind(server);
+
+  server.tool = ((...args: unknown[]) => {
+    const toolName = args[0] as string;
+    const lastIndex = args.length - 1;
+
+    if (typeof args[lastIndex] === 'function') {
+      const originalHandler = args[lastIndex] as (...handlerArgs: unknown[]) => Promise<unknown>;
+      args[lastIndex] = withConnectionGuard(toolName, originalHandler);
+    }
+
+    return (originalTool as (...a: unknown[]) => unknown)(...args);
+  }) as typeof server.tool;
+
+  return server;
+}
 
 export function registerAllTools(
   server: McpServer,
@@ -18,14 +37,16 @@ export function registerAllTools(
   dbName: string,
   mode: string
 ): void {
-  registerDatabaseTools(server, client, mode);
-  registerCollectionTools(server, db, mode);
-  registerDocumentTools(server, db, mode);
-  registerSchemaTools(server, db);
-  registerIndexManagementTools(server, db, mode);
-  registerAdvancedOperations(server, db, mode);
-  registerDataQualityTools(server, db, mode);
-  registerTemporalTools(server, db, mode);
-  registerMonitoringTools(server, client, db, dbName, mode);
-  registerLiveMonitoringTools(server, db, mode);
+  const guardedServer = wrapServerWithConnectionGuard(server);
+
+  registerDatabaseTools(guardedServer, client, mode);
+  registerCollectionTools(guardedServer, db, mode);
+  registerDocumentTools(guardedServer, db, mode);
+  registerSchemaTools(guardedServer, db);
+  registerIndexManagementTools(guardedServer, db, mode);
+  registerAdvancedOperations(guardedServer, db, mode);
+  registerDataQualityTools(guardedServer, db, mode);
+  registerTemporalTools(guardedServer, db, mode);
+  registerMonitoringTools(guardedServer, client, db, dbName, mode);
+  registerLiveMonitoringTools(guardedServer, db, mode);
 }

--- a/src/utils/connection-guard.ts
+++ b/src/utils/connection-guard.ts
@@ -1,0 +1,71 @@
+import { MongoNetworkError, MongoServerClosedError, MongoNotConnectedError } from 'mongodb';
+import { logError } from './logger.js';
+
+const CONNECTION_ERROR_NAMES = [
+  'MongoNetworkError',
+  'MongoServerClosedError',
+  'MongoNotConnectedError',
+  'MongoTopologyClosedError',
+  'MongoNetworkTimeoutError',
+];
+
+const CONNECTION_ERROR_PATTERNS = [
+  'topology was destroyed',
+  'topology is closed',
+  'connection closed',
+  'connection pool cleared',
+  'server selection timed out',
+  'not connected',
+  'client must be connected',
+];
+
+export function isConnectionError(error: unknown): boolean {
+  if (
+    error instanceof MongoNetworkError ||
+    error instanceof MongoServerClosedError ||
+    error instanceof MongoNotConnectedError
+  ) {
+    return true;
+  }
+
+  if (error instanceof Error) {
+    if (CONNECTION_ERROR_NAMES.includes(error.constructor.name)) {
+      return true;
+    }
+
+    const message = error.message.toLowerCase();
+    return CONNECTION_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+  }
+
+  return false;
+}
+
+const CONNECTION_LOST_MESSAGE =
+  'MongoDB connection lost. The server can no longer communicate with the database. ' +
+  'Please restart the MCP server to re-establish the connection.';
+
+export function withConnectionGuard<TArgs, TResult>(
+  toolName: string,
+  handler: (args: TArgs) => Promise<TResult>
+): (args: TArgs) => Promise<TResult> {
+  return async (args: TArgs): Promise<TResult> => {
+    try {
+      return await handler(args);
+    } catch (error) {
+      if (isConnectionError(error)) {
+        logError(toolName, error, args);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `[${toolName}] ${CONNECTION_LOST_MESSAGE}`,
+            },
+          ],
+        } as TResult;
+      }
+
+      throw error;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- Added `src/utils/connection-guard.ts` with `isConnectionError()` detection and `withConnectionGuard()` higher-order function
- Applied the guard centrally in `src/tools/index.ts` by wrapping `server.tool()` — all tools get connection error protection without modifying any individual tool file
- Added a `ping` verification in `src/index.ts` after `client.connect()` to confirm the database is reachable before setting up the MCP server

## How it works

When a tool handler throws a MongoDB connection-related error (`MongoNetworkError`, `MongoServerClosedError`, `MongoNotConnectedError`, topology errors), the guard catches it and returns a clear MCP text response:

> `[toolName] MongoDB connection lost. The server can no longer communicate with the database. Please restart the MCP server to re-establish the connection.`

When the connection is healthy, tool behavior is completely unchanged — the guard is transparent.

## Files changed

| File | Change |
|------|--------|
| `src/utils/connection-guard.ts` | **New** — `isConnectionError()` + `withConnectionGuard()` |
| `src/tools/index.ts` | Wrap `server.tool()` to apply connection guard to all handlers |
| `src/index.ts` | Add `ping` check after `client.connect()` |

## Test plan

- [ ] Verify `pnpm build` compiles without errors
- [ ] Verify normal tool operations work unchanged with a healthy connection
- [ ] Simulate connection drop and verify tools return the friendly error message instead of crashing

Fixes #17