### PR TITLE
fix: normalize ObjectId in relationship cycle detection

### DIFF
--- a/src/tools/data-quality.ts
+++ b/src/tools/data-quality.ts
@@ -1676,7 +1676,7 @@ async function exploreDocumentRelationships(
   includeReverse: boolean,
   visited: Set<string> = new Set()
 ): Promise<any> {
-  const docKey = `${rootCollection}:${rootDoc._id}`;
+  const docKey = `${rootCollection}:${String(rootDoc._id)}`;
 
   // Prevent circular references
   if (visited.has(docKey)) {


### PR DESCRIPTION
## Summary
- Normalize `_id` to string using `String(rootDoc._id)` when constructing cycle-detection keys in `exploreDocumentRelationships`
- Prevents potential infinite loop/stack overflow when `_id` is an ObjectId object whose template literal interpolation may produce inconsistent keys

## Details
The `exploreDocumentRelationships` helper in `src/tools/data-quality.ts` uses a `visited` Set to detect cycles during recursive relationship traversal. The visited key was built with template literal interpolation (`${rootDoc._id}`), which for ObjectId objects could produce inconsistent string representations. Wrapping in `String()` ensures deterministic key generation.

One-line change in `src/tools/data-quality.ts:1679`.

Fixes #18