### PR TITLE
fix: validate structural shape of bulkWrite operation bodies

### DIFF
--- a/src/utils/bulk-write-validator.ts
+++ b/src/utils/bulk-write-validator.ts
@@ -67,6 +67,25 @@ export function validateBulkOperations(operations: Record<string, any>[]): BulkV
 
     const opBody = op[opType];
 
+    // Validate opBody is a non-null object
+    if (opBody === null || opBody === undefined || typeof opBody !== 'object' || Array.isArray(opBody)) {
+      return {
+        valid: false,
+        error: `Operation ${opIndex} (${opType}): expected operation body to be a non-null object, got ${opBody === null ? 'null' : Array.isArray(opBody) ? 'array' : typeof opBody}.`,
+      };
+    }
+
+    // Validate filter is a non-null, non-array object for filter-based operations
+    if (OPERATIONS_WITH_FILTER.includes(opType) && opBody.filter !== undefined) {
+      const filter = opBody.filter;
+      if (filter === null || typeof filter !== 'object' || Array.isArray(filter)) {
+        return {
+          valid: false,
+          error: `Operation ${opIndex} (${opType}): filter expected to be a non-null object, got ${filter === null ? 'null' : Array.isArray(filter) ? 'array' : typeof filter}.`,
+        };
+      }
+    }
+
     // Check empty filters on multi-doc operations
     if (MULTI_DOC_OPERATIONS.includes(opType)) {
       const filter = opBody?.filter;


### PR DESCRIPTION
## Summary

Follow-up to #39. Adds structural validation for bulkWrite sub-operation bodies:

- Reject primitive, null, and array `opBody` values (e.g. `{ updateOne: 123 }`) with a clear error instead of falling through to the MongoDB driver
- Reject non-object `filter` fields (strings, arrays) on filter-based operations before the dangerous-operator scan runs

Not a security gap (the operator scanner safely returns `{found: false}` on primitives), but gives validator-level errors instead of cryptic driver failures.

## Test plan

- [x] 8 new tests covering primitive/null/array opBody, string/array filter, correct index reporting
- [x] All 179 tests pass (0 regressions)