### PR TITLE
chore: add server.json and mcpName for MCP Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-scout-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Scout your MongoDB databases with AI - A production-ready MCP server with safety features, live monitoring, and data quality tools",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.3",
     "vitest": "^3.0.5"
-  }
+  },
+  "mcpName": "io.github.bluwork/mongo-scout-mcp"
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+  "name": "io.github.bluwork/mongo-scout-mcp",
+  "description": "Scout your MongoDB databases with AI - MCP server with safety features, live monitoring, and data quality tools",
+  "version": "1.0.1",
+  "packages": [
+    {
+      "identifier": "mongo-scout-mcp",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "registryType": "npm",
+      "transport": { "type": "stdio" },
+      "version": "1.0.1",
+      "packageArguments": [
+        {
+          "description": "Server mode: read-only (default) or read-write",
+          "isRequired": false,
+          "format": "string",
+          "name": "--mode",
+          "value": "read-only"
+        },
+        {
+          "description": "MongoDB connection URI",
+          "isRequired": false,
+          "format": "string",
+          "valueHint": "mongodb-uri",
+          "value": "mongodb://localhost:27017"
+        },
+        {
+          "description": "Database name to use",
+          "isRequired": false,
+          "format": "string",
+          "valueHint": "database-name",
+          "value": "test"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/bluwork/mongo-scout-mcp"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `server.json` with package arguments (--mode, mongodb-uri, database-name) for MCP Registry publishing
- Add `mcpName` field to `package.json`
- Version bump to 1.0.2 (already published to npm)

## Test plan
- [ ] Verify `mcp-publisher publish server.json` succeeds after merge